### PR TITLE
fix: fix font issue in safari

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -58,15 +58,15 @@
     --tw-shadow-color: 0 0 #d1c3c300;
   }
   .p {
-    @apply text-left font-inter text-lg lg:text-xl;
+    @apply text-left font-inter text-lg font-normal lg:text-xl;
   }
 
   .h1 {
-    @apply text-left font-bebas text-4xl font-bold md:text-5xl lg:text-6xl;
+    @apply text-left font-bebas text-4xl font-normal md:text-5xl lg:text-6xl;
   }
 
   .h2 {
-    @apply text-left font-bebas text-3xl font-bold md:text-4xl lg:text-5xl;
+    @apply text-left font-bebas text-3xl font-normal md:text-4xl lg:text-5xl;
   }
 
   .h3 {
@@ -78,7 +78,7 @@
   }
 
   .small {
-    @apply font-inter text-xs text-gray-500;
+    @apply font-inter text-xs font-normal text-gray-500;
   }
 }
 


### PR DESCRIPTION
This pull request updates the `globals.css` file to standardize font weights across various text styles. The changes ensure a consistent visual hierarchy by modifying the font weight for headings, paragraphs, and small text.

Font weight adjustments:

* Updated the `.p` class to explicitly include `font-normal` for paragraph text.
* Changed the `.h1` and `.h2` classes to use `font-normal` instead of `font-bold` for headings.
* Modified the `.small` class to explicitly include `font-normal` for small text.