### PR TITLE
fix(metadata): update fields in all pages

### DIFF
--- a/ui/src/app/blog/[slug]/page.tsx
+++ b/ui/src/app/blog/[slug]/page.tsx
@@ -32,24 +32,19 @@ export async function generateMetadata({ params }: BlogPostPageProps) {
   }
 
   return {
-    title: `${post.title} | Blog | Insuasti.com`,
+    title: `${post.title} | Blog | insuasti.com`,
     description: post.excerpt,
     openGraph: {
       title: post.title,
       description: post.excerpt,
       type: 'article',
       publishedTime: post.date,
-      authors: [post.author],
       tags: post.tags,
-      url: `https://www.insuasti.com/blog/${slug}`,
-      images: [
-        {
-          url: `https://www.insuasti.com/og.png`,
-          width: 1200,
-          height: 630,
-          alt: post.title,
-        },
-      ],
+      url: `https://insuasti.com/blog/${slug}`,
+    },
+    twitter: {
+      title: post.title,
+      description: post.excerpt,
     },
   };
 }

--- a/ui/src/app/blog/page.tsx
+++ b/ui/src/app/blog/page.tsx
@@ -7,6 +7,21 @@ import { getPaginatedPosts, getAllTags } from '@/lib/blog-utils';
 import { BlogSearchParams } from '@/lib/blog-types';
 import { Suspense } from 'react';
 
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Blog | insuasti.com',
+  description: 'Articles on web development, electronics, and creative problem-solving.',
+  openGraph: {
+    title: 'Blog | insuasti.com',
+    description: 'Articles on web development, electronics, and creative problem-solving.',
+    url: 'https://insuasti.com/blog',
+  },
+  twitter: {
+    title: 'Blog | insuasti.com',
+    description: 'Articles on web development, electronics, and creative problem-solving.',
+  },
+};
 interface BlogPageProps {
   searchParams: Promise<BlogSearchParams>;
 }

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -11,11 +11,11 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'insuasti.com | Juan Insuasti - Senior Frontend Developer',
     description: 'A playground site where I showcase my projects and host my personal blog.',
-    url: 'https://www.insuasti.com',
+    url: 'https://insuasti.com',
     siteName: 'Insuasti.com',
     images: [
       {
-        url: 'https://www.insuasti.com/og.png',
+        url: 'https://insuasti.com/og.png',
         width: 1200,
         height: 630,
         alt: "Juan Insuasti's Portfolio",
@@ -24,7 +24,20 @@ export const metadata: Metadata = {
     locale: 'en_US',
     type: 'website',
   },
-  authors: [{ name: 'Juan Insuasti', url: 'https://www.insuasti.com' }],
+  authors: [{ name: 'Juan Insuasti', url: 'https://insuasti.com' }],
+  twitter: {
+    card: 'summary_large_image',
+    site: '@JuanInsuasti4',
+    creator: '@JuanInsuasti4',
+    title: 'insuasti.com | Juan Insuasti - Frontend Developer',
+    description: 'A playground site where I showcase my projects and host my personal blog.',
+    images: ['https://insuasti.com/og.png'],
+  },
+  metadataBase: new URL('https://insuasti.com'),
+  alternates: {
+    canonical: '/',
+  },
+  themeColor: '#008000', // change to your brand color
 };
 
 export default function RootLayout({


### PR DESCRIPTION
This pull request updates metadata for the blog and site layout to improve SEO and social sharing, while also standardizing URLs to use the non-www version (`insuasti.com`). The changes enhance Open Graph and Twitter card support and ensure consistency across all metadata references.

**Metadata improvements for SEO and social sharing:**

* Added and expanded Twitter card metadata, including card type, site, creator, title, description, and images in `layout.tsx` and blog pages. [[1]](diffhunk://#diff-9e3e8e10948da96b615930189732f9ec1fe0f7b7967debc8471807f35b4eec0fL27-R40) [[2]](diffhunk://#diff-3d406ae0e78978130fa4dae99eb8adcbdb0a509708bfcdd83b52bc7adf079b96R10-R24) [ui/src/app/blog/[slug]/page.tsxL35-R47](diffhunk://#diff-3d22b67ba21fa39e7d261d767fdb4f6c1d05ff6b0b29d3bdbd61249b79ebb671L35-R47))
* Improved Open Graph metadata by updating titles, descriptions, and image URLs for better link previews and uniform branding. [[1]](diffhunk://#diff-9e3e8e10948da96b615930189732f9ec1fe0f7b7967debc8471807f35b4eec0fL14-R18) [[2]](diffhunk://#diff-3d406ae0e78978130fa4dae99eb8adcbdb0a509708bfcdd83b52bc7adf079b96R10-R24) [ui/src/app/blog/[slug]/page.tsxL35-R47](diffhunk://#diff-3d22b67ba21fa39e7d261d767fdb4f6c1d05ff6b0b29d3bdbd61249b79ebb671L35-R47))

**Standardization of URLs:**

* Changed all references from `www.insuasti.com` to `insuasti.com` for canonical consistency and improved SEO. [[1]](diffhunk://#diff-9e3e8e10948da96b615930189732f9ec1fe0f7b7967debc8471807f35b4eec0fL14-R18) [[2]](diffhunk://#diff-9e3e8e10948da96b615930189732f9ec1fe0f7b7967debc8471807f35b4eec0fL27-R40) [ui/src/app/blog/[slug]/page.tsxL35-R47](diffhunk://#diff-3d22b67ba21fa39e7d261d767fdb4f6c1d05ff6b0b29d3bdbd61249b79ebb671L35-R47), [[3]](diffhunk://#diff-3d406ae0e78978130fa4dae99eb8adcbdb0a509708bfcdd83b52bc7adf079b96R10-R24)

**Other metadata enhancements:**

* Added canonical alternate and theme color to the site metadata for better browser and search engine support.
* Removed unused or redundant Open Graph fields (such as `authors` and image arrays) from blog post metadata to streamline the output. ([ui/src/app/blog/[slug]/page.tsxL35-R47](diffhunk://#diff-3d22b67ba21fa39e7d261d767fdb4f6c1d05ff6b0b29d3bdbd61249b79ebb671L35-R47))