### PR TITLE
fix(og): add image version to prevent caching

### DIFF
--- a/ui/src/app/blog/[slug]/page.tsx
+++ b/ui/src/app/blog/[slug]/page.tsx
@@ -43,7 +43,7 @@ export async function generateMetadata({ params }: BlogPostPageProps) {
       url: `https://insuasti.com/blog/${slug}`,
       images: [
         {
-          url: 'https://insuasti.com/og.png',
+          url: 'https://insuasti.com/og.png?v=2',
           width: 1200,
           height: 630,
           alt: `${post.title} | preview`,

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     siteName: 'Insuasti.com',
     images: [
       {
-        url: 'https://insuasti.com/og.png',
+        url: 'https://insuasti.com/og.png?v=2',
         width: 1200,
         height: 630,
         alt: "Juan Insuasti's Portfolio",
@@ -31,7 +31,7 @@ export const metadata: Metadata = {
     creator: '@JuanInsuasti4',
     title: 'insuasti.com | Juan Insuasti - Frontend Developer',
     description: 'A playground site where I showcase my projects and host my personal blog.',
-    images: ['https://insuasti.com/og.png'],
+    images: ['https://insuasti.com/og.png?v=2'],
   },
   metadataBase: new URL('https://insuasti.com'),
   alternates: {


### PR DESCRIPTION
This pull request updates the Open Graph image URLs used for metadata across the blog and site layout. The changes ensure that the latest version of the preview image is used by adding a cache-busting query parameter to the image URL.

Metadata improvements:

* Updated the Open Graph image URL in the blog post metadata to `https://insuasti.com/og.png?v=2` to ensure the most recent image is displayed in link previews. ([ui/src/app/blog/[slug]/page.tsxL46-R46](diffhunk://#diff-3d22b67ba21fa39e7d261d767fdb4f6c1d05ff6b0b29d3bdbd61249b79ebb671L46-R46))
* Updated the Open Graph image URL in the site-wide metadata within `ui/src/app/layout.tsx` to use the new versioned image for both the main metadata and Twitter card metadata. [[1]](diffhunk://#diff-9e3e8e10948da96b615930189732f9ec1fe0f7b7967debc8471807f35b4eec0fL18-R18) [[2]](diffhunk://#diff-9e3e8e10948da96b615930189732f9ec1fe0f7b7967debc8471807f35b4eec0fL34-R34)