### PR TITLE
fix(json-ld): missing properties

### DIFF
--- a/ui/src/components/JsonLd.tsx
+++ b/ui/src/components/JsonLd.tsx
@@ -1,5 +1,4 @@
-import Script from 'next/script';
-
+import Head from 'next/head';
 interface JsonLdProps {
   data: object | object[];
 }
@@ -9,16 +8,15 @@ interface JsonLdProps {
  * Accepts either a single schema object or an array of schema objects
  */
 export function JsonLd({ data }: JsonLdProps) {
-  const jsonData = Array.isArray(data) ? data : [data];
   return (
-    <>
-      <Script
+    <Head>
+      <script
         id={`jsonld`}
         type="application/ld+json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify(jsonData),
+          __html: JSON.stringify(data).replace(/</g, '\\u003c'),
         }}
       />
-    </>
+    </Head>
   );
 }

--- a/ui/src/lib/jsonld/blog-page.ts
+++ b/ui/src/lib/jsonld/blog-page.ts
@@ -37,12 +37,12 @@ export const blogPageJsonLd = () => {
     {
       '@context': 'https://schema.org',
       '@type': 'WebPage',
-      name: 'Blog | Insuasti',
+      name: 'Blog | insuasti.com',
       url: 'https://insuasti.com/blog',
       description: 'Articles on web development, electronics, and creative problem-solving.',
       isPartOf: {
         '@type': 'WebSite',
-        name: 'Insuasti',
+        name: 'Juan Insuasti | insuasti.com',
         url: 'https://insuasti.com/',
       },
       author: {

--- a/ui/src/lib/jsonld/blog-post.ts
+++ b/ui/src/lib/jsonld/blog-post.ts
@@ -33,7 +33,7 @@ export const blogPostJsonLd = (post: BlogPost) => {
       },
       isPartOf: {
         '@type': 'Blog',
-        name: 'Insuasti Blog',
+        name: 'Blog | insuasti.com',
         url: 'https://insuasti.com/blog',
       },
       image: {

--- a/ui/src/lib/jsonld/homepage.ts
+++ b/ui/src/lib/jsonld/homepage.ts
@@ -24,8 +24,28 @@ export const homepageJsonLd = () => {
       hasOccupation: {
         '@type': 'Occupation',
         name: 'Frontend Developer',
+        description:
+          'Building user-friendly web applications with a focus on performance and accessibility.',
+        estimatedSalary: {
+          '@type': 'MonetaryAmount',
+          currency: 'USD',
+          value: {
+            '@type': 'QuantitativeValue',
+            value: 0,
+            unitText: 'MONTH',
+          },
+        },
+        occupationLocation: {
+          '@type': 'Place',
+          name: 'Medellín, Colombia',
+          address: {
+            '@type': 'PostalAddress',
+            addressLocality: 'Medellín',
+            addressCountry: 'CO',
+          },
+        },
       },
-      author: [
+      citation: [
         {
           '@type': 'CreativeWork',
           name: 'TTRPG Platform',
@@ -52,7 +72,7 @@ export const homepageJsonLd = () => {
     {
       '@context': 'https://schema.org',
       '@type': 'WebSite',
-      name: 'Insuasti - Juan Insuasti Portfolio',
+      name: 'Juan Insuasti | insuasti.com',
       url: 'https://insuasti.com/',
       description:
         'Portfolio and blog of Juan Insuasti, frontend developer specializing in React, TypeScript, and modern web technologies.',

--- a/ui/src/lib/jsonld/projects-page.ts
+++ b/ui/src/lib/jsonld/projects-page.ts
@@ -72,12 +72,12 @@ export const projectsPageJsonLd = (projects: ProjectMeta[] = []) => {
     {
       '@context': 'https://schema.org',
       '@type': 'WebPage',
-      name: 'Projects | Insuasti',
+      name: 'Projects | insuasti.com',
       url: 'https://insuasti.com/projects',
       description: "A curated selection of web and electronics projects I've built.",
       isPartOf: {
         '@type': 'WebSite',
-        name: 'Insuasti',
+        name: 'Juan Insuasti | insuasti.com',
         url: 'https://insuasti.com/',
       },
       author: {


### PR DESCRIPTION
This pull request updates the handling and content of JSON-LD schema data for SEO and rich results, improves security, and standardizes branding references across the site. The main changes include switching from Next.js's `Script` to `Head` for injecting JSON-LD, escaping JSON to prevent XSS, and updating schema details for more accurate and consistent metadata.

**SEO and Schema Data Improvements:**

* Changed `JsonLd` component to use `Head` instead of `Script` for injecting JSON-LD, and added escaping of `<` characters in the JSON to prevent XSS vulnerabilities (`ui/src/components/JsonLd.tsx`). [[1]](diffhunk://#diff-7a37250e57c3199677db99fdc0ec22484e51dfdffa2052566384340564b5e09eL1-R1) [[2]](diffhunk://#diff-7a37250e57c3199677db99fdc0ec22484e51dfdffa2052566384340564b5e09eL12-R20)
* Added more detailed occupation information, salary, and location to the homepage schema, and replaced `workExample` with `citation` for better semantic accuracy (`ui/src/lib/jsonld/homepage.ts`).

**Branding and Metadata Standardization:**

* Updated schema objects for blog, homepage, and projects pages to consistently use "Juan Insuasti | insuasti.com" and related branding, improving search appearance and coherence (`ui/src/lib/jsonld/blog-page.ts`, `ui/src/lib/jsonld/homepage.ts`, `ui/src/lib/jsonld/projects-page.ts`). [[1]](diffhunk://#diff-746fef78be4d855a0e727c18a5899f351bc41c2f38d36b8c140bd58255336656L40-R45) [[2]](diffhunk://#diff-9d2bfcf36542e2c06d1ff85808aafcbbfa00c9df63715312b48d87f69c1786c7L55-R75) [[3]](diffhunk://#diff-61563599a3d7dd827363480f12348c9fdb498c40b68019af7d62c69ced400411L75-R80)
* Updated blog post schema to use "Blog | insuasti.com" for the `isPartOf` property (`ui/src/lib/jsonld/blog-post.ts`).