### PR TITLE
feat(blog): remove author

### DIFF
--- a/ui/src/components/features/blog/BlogPostCard.tsx
+++ b/ui/src/components/features/blog/BlogPostCard.tsx
@@ -18,8 +18,6 @@ export function BlogPostCard({ post }: BlogPostCardProps) {
           <div>
             <div className="mb-3 flex items-center gap-2 text-sm text-muted-foreground">
               <time dateTime={post.date}>{formatDate(post.date)}</time>
-              <span>•</span>
-              <span>{post.author}</span>
             </div>
 
             <Link href={`/blog/${post.slug}`} className="block group-hover:no-underline">

--- a/ui/src/components/features/blog/BlogPostContent.tsx
+++ b/ui/src/components/features/blog/BlogPostContent.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 
-import { Calendar, Clock, User } from 'lucide-react';
+import { Calendar, Clock } from 'lucide-react';
 
 import { Badge } from '@ui/Badge';
 import { Typography } from '@ui/Typography';
@@ -28,11 +28,6 @@ export function BlogPostContent({ post, htmlContent }: BlogPostContentProps) {
           <div className="flex items-center gap-1">
             <Calendar className="h-4 w-4" />
             <time dateTime={post.date}>{formatDate(post.date)}</time>
-          </div>
-
-          <div className="flex items-center gap-1">
-            <User className="h-4 w-4" />
-            <span>{post.author}</span>
           </div>
 
           <div className="flex items-center gap-1">


### PR DESCRIPTION
This pull request makes minor UI changes to the blog components, specifically removing the display of the post author from both the blog post card and blog post content views.

Blog UI cleanup:

* Removed the author name and associated icon from the metadata section in both `BlogPostCard` and `BlogPostContent` components to simplify the blog post presentation. [[1]](diffhunk://#diff-6e1f84de91baf8dcb20770a2e730f3bcb1c9331513a9e15c10ef0a8c5c38b28dL21-L22) [[2]](diffhunk://#diff-0cc07ed138e063d18aa247938af37f5dedd63f3c452ffa9a080035d5bf0e4fddL33-L37)
* Removed the unused `User` icon import from `BlogPostContent.tsx` since the author display was removed.